### PR TITLE
Use standalone document class for single-table compiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Single-table compiles use the `standalone` document class; pages auto-fit the table (#21).
+
+### Deprecated
+- `--landscape` and `--no-resize` (and API/Python equivalents) are no-ops; removal in 2.0.
+
+### Fixed
+- Tabular validation strips LaTeX comments before counting `\begin`/`\end` pairs.
+
 ## [1.4.0] - 2026-05-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -26,11 +26,10 @@ Intercept & 1.23 & 0.045 \\
 And automatically wraps them into complete, compilable LaTeX documents with:
 - Auto-detected packages (booktabs, tabularx, siunitx, etc.)
 - Proper document structure and preambles
-- Smart table resizing to fit pages
+- Auto-fit page sized to the table
 - Multi-file batch processing with error recovery
 - Combined PDFs with table of contents
 - PNG output with automatic cropping, SVG support
-- Landscape orientation and custom formatting
 - Enhanced error reporting with suggestions
 
 ## Quick Start
@@ -74,8 +73,8 @@ tabwrap regression_table.tex
 # Process all tables in a folder
 tabwrap ./results_tables/
 
-# Output PNG with landscape orientation
-tabwrap table.tex -p --landscape
+# Output PNG
+tabwrap table.tex -p
 
 # Batch process with combined PDF
 tabwrap ./tables/ -r -c    # recursive + combine PDFs
@@ -121,8 +120,6 @@ tabwrap folder/ -j                    # Parallel processing (4-6x faster)
 tabwrap folder/ -c                    # Combine into single PDF with TOC
 
 # Layout and formatting
-tabwrap table.tex --landscape         # Landscape orientation
-tabwrap table.tex --no-resize         # Disable auto-resizing
 tabwrap table.tex --header            # Show filename as header
 ```
 
@@ -162,8 +159,6 @@ Processing Options:
   -c, --combine            Combine multiple PDFs with table of contents
 
 Formatting Options:
-  --landscape              Use landscape orientation
-  --no-resize              Disable automatic table resizing
   --header                 Show filename as header in output
   --packages TEXT          Comma-separated LaTeX packages (auto-detected if empty)
 
@@ -188,8 +183,6 @@ tabwrap folder/ -j                    # Parallel processing (faster)
 tabwrap folder/ -c                    # Combined PDF with TOC
 
 # Formatting options
-tabwrap table.tex --landscape         # Landscape orientation
-tabwrap table.tex --no-resize         # No auto-resizing
 tabwrap table.tex --header            # Show filename header
 
 # Output control
@@ -210,7 +203,6 @@ result = compiler.compile_tex(
     input_path="table.tex",
     output_dir="output/",
     png=True,
-    landscape=True
 )
 print(f"Compiled to: {result}")
 ```
@@ -245,7 +237,7 @@ esttab using "regression_results.tex", replace booktabs
 library(xtable)
 xtable(model) %>%
   print(file = "model_table.tex", include.rownames = FALSE)
-system("tabwrap model_table.tex --landscape")
+system("tabwrap model_table.tex")
 ```
 
 ### Python

--- a/tabwrap/api.py
+++ b/tabwrap/api.py
@@ -55,8 +55,8 @@ class HealthResponse(BaseModel):
 
 class CompileOptions(BaseModel):
     packages: str = Field("", description="Comma-separated LaTeX packages")
-    landscape: bool = Field(False, description="Use landscape orientation")
-    no_rescale: bool = Field(False, description="Disable automatic table resizing")
+    landscape: bool = Field(False, description="[Deprecated, no-op] Output is auto-fit by the standalone document class")
+    no_rescale: bool = Field(False, description="[Deprecated, no-op] Output is auto-fit by the standalone document class")
     show_filename: bool = Field(False, description="Show filename as header")
     formats: str = Field("", description="Comma-separated formats: pdf,png,svg. Defaults to pdf.")
     png: bool = Field(False, description="Alias: include png in formats")
@@ -124,8 +124,8 @@ def create_app():
         request: Request,
         file: UploadFile = File(..., description="LaTeX table file (.tex)"),
         packages: str = Form("", description="Comma-separated LaTeX packages"),
-        landscape: bool = Form(False, description="Use landscape orientation"),
-        no_rescale: bool = Form(False, description="Disable automatic table resizing"),
+        landscape: bool = Form(False, description="[Deprecated, no-op] Output is auto-fit by the standalone document class"),
+        no_rescale: bool = Form(False, description="[Deprecated, no-op] Output is auto-fit by the standalone document class"),
         show_filename: bool = Form(False, description="Show filename as header"),
         formats: str = Form("", description="Comma-separated formats: pdf,png,svg. Defaults to pdf."),
         png: bool = Form(False, description="Alias: include png in formats"),

--- a/tabwrap/cli.py
+++ b/tabwrap/cli.py
@@ -17,8 +17,8 @@ from .result import Format, resolve_formats
 @click.option("-o", "--output", type=click.Path(), default=".", help="Output directory (default: current directory)")
 @click.option("--suffix", default="_compiled", help="Output filename suffix (default: '_compiled')")
 @click.option("--packages", default="", help="Comma-separated LaTeX packages (auto-detected if empty)")
-@click.option("--landscape", is_flag=True, help="Use landscape orientation")
-@click.option("--no-resize", is_flag=True, help="Disable automatic table resizing")
+@click.option("--landscape", is_flag=True, help="[Deprecated, no-op] Output is auto-fit by the standalone document class")
+@click.option("--no-resize", is_flag=True, help="[Deprecated, no-op] Output is auto-fit by the standalone document class")
 @click.option("--header", is_flag=True, help="Show filename as header in output")
 @click.option("--keep-tex", is_flag=True, help="Keep generated LaTeX files and compilation logs for debugging")
 @click.option(

--- a/tabwrap/core.py
+++ b/tabwrap/core.py
@@ -74,6 +74,9 @@ class TabWrap:
         *,
         suffix: str = "_compiled",
         packages: str = "",
+        # `landscape` and `no_rescale` are deprecated no-ops kept for backwards
+        # compatibility with shell scripts, API form payloads, and the web UI
+        # in the tabwrap-web repo. Remove in 2.0.
         landscape: bool = False,
         no_rescale: bool = False,
         show_filename: bool = False,
@@ -94,6 +97,9 @@ class TabWrap:
         """
         if (png or svg) and formats:
             logger.warning("png/svg flags ignored because explicit formats were provided")
+        if landscape or no_rescale:
+            ignored = ", ".join(name for name, on in (("landscape", landscape), ("no_rescale", no_rescale)) if on)
+            logger.warning(f"{ignored} option(s) ignored: the standalone document class auto-fits content")
         resolved_formats = resolve_formats(formats, png=png, svg=svg)
         needs_image_convert = bool(resolved_formats & {Format.PNG})
         self.check_dependencies(require_convert=needs_image_convert)
@@ -272,38 +278,19 @@ class TabWrap:
         user_packages = [f"\\usepackage{{{pkg}}}" for pkg in options.get("packages", "").split(",") if pkg]
         all_packages = "\n".join(user_packages) + "\n" + "\n".join(detected_packages)
 
-        has_longtable = "\\begin{longtable}" in content
-        has_table = "\\begin{table}" in content
-
-        if not options.get("no_rescale"):
-            all_packages += "\n\\usepackage{graphicx}"
-            if not has_longtable and not has_table:
-                content = r"\resizebox{\linewidth}{!}{" + content + "}"
-
         underscore_package = ""
         if options.get("show_filename") and "_" in tex_file.name:
             underscore_package = "\\usepackage{underscore}  % Handle underscores in filenames"
 
         header = ""
         if options.get("show_filename"):
-            header = r"\texttt{" + clean_filename_for_display(tex_file.name) + r"}"
-        pagestyle = "plain" if options.get("combine_pdf") else "empty"
-
-        geometry_options = ["margin=1cm"]
-        if options.get("landscape"):
-            geometry_options.append("landscape")
-        geometry_package = f"\\usepackage[{','.join(geometry_options)}]{{geometry}}"
-
-        if not has_longtable and not has_table:
-            content = r"\begin{center}" + "\n" + content + "\n" + r"\end{center}"
+            header = r"\texttt{" + clean_filename_for_display(tex_file.name) + r"}\par\medskip"
 
         prepared = TexTemplates.SINGLE_TABLE.format(
             packages=all_packages,
             underscore=underscore_package,
-            geometry=geometry_package,
             header=header,
             content=content,
-            pagestyle=pagestyle,
         )
         return prepared, detected_packages
 

--- a/tabwrap/latex/templates.py
+++ b/tabwrap/latex/templates.py
@@ -5,13 +5,14 @@
 class TexTemplates:
     """Collection of LaTeX templates and document structures."""
 
-    # Template for single table compilation
+    # Template for single table compilation. The standalone class with
+    # `varwidth` auto-fits the page to the table — no fixed paper size,
+    # so tall tables don't overflow and small tables don't leave whitespace
+    # for the downstream PNG/SVG/embed pipeline to crop around.
     SINGLE_TABLE = r"""
-    \documentclass{{article}}
-    {geometry}
+    \documentclass[varwidth=\maxdimen,border=10pt]{{standalone}}
     {underscore}
     {packages}  % Inserted packages
-    \pagestyle{{{pagestyle}}}
     \begin{{document}}
     {header}
     {content}

--- a/tabwrap/latex/validation.py
+++ b/tabwrap/latex/validation.py
@@ -1,5 +1,6 @@
 # tex_compiler/utils/validation.py
 import os
+import re
 from pathlib import Path
 
 from ..exceptions import InvalidLatexError
@@ -52,6 +53,14 @@ def validate_output_dir(dir_path: str | Path) -> Path:
     return path
 
 
+_COMMENT_RE = re.compile(r"(?<!\\)%.*$", re.MULTILINE)
+
+
+def _strip_latex_comments(content: str) -> str:
+    """Drop LaTeX line comments so validators don't count tags inside them."""
+    return _COMMENT_RE.sub("", content)
+
+
 def is_valid_tabular_content(content: str) -> tuple[bool, str]:
     """
     Check if content appears to be a valid LaTeX table environment.
@@ -66,6 +75,10 @@ def is_valid_tabular_content(content: str) -> tuple[bool, str]:
     """
     if not content.strip():
         return False, "Empty content"
+
+    # Strip comments so a stray `% \end{tabular}` doesn't fool the begin/end
+    # tag counts below.
+    content = _strip_latex_comments(content)
 
     # Check which table environments are present
     has_tabular = "\\begin{tabular}" in content

--- a/tests/test_cli_options.py
+++ b/tests/test_cli_options.py
@@ -155,10 +155,12 @@ def test_option_combinations(runner, sample_tex, tmp_path):
     # Header with underscore package
     assert r"\texttt{test\_under\_score.tex}" in tex_content
     assert r"\usepackage{underscore}" in tex_content
-    # No resize
+    # No resize / landscape are now no-ops; the standalone document class
+    # auto-fits the page so neither resizebox wrapping nor a landscape
+    # geometry option should appear.
     assert r"\resizebox" not in tex_content
-    # Landscape
-    assert r"landscape" in tex_content
+    assert r"\documentclass[varwidth" in tex_content
+    assert r"landscape" not in tex_content
 
 
 def test_combine_single_file(runner, sample_tex, tmp_path):

--- a/tests/test_standalone_template.py
+++ b/tests/test_standalone_template.py
@@ -1,0 +1,82 @@
+"""Regression tests for issue #21: standalone document class for single-table compiles."""
+
+import logging
+
+import fitz
+import pytest
+
+from tabwrap.core import CompilerMode, TabWrap
+from tabwrap.latex import check_latex_dependencies
+
+pytestmark = pytest.mark.skipif(not check_latex_dependencies()["pdflatex"], reason="pdflatex not available")
+
+
+def _write_tabular(path, rows: int) -> None:
+    body = ["\\begin{tabular}{lcc}", "\\toprule", "Var & Mean & SD \\\\", "\\midrule"]
+    body += [f"Var {i} & {i*10}.{i % 10} & {i*5}.{i % 10} \\\\" for i in range(1, rows + 1)]
+    body += ["\\bottomrule", "\\end{tabular}", ""]
+    path.write_text("\n".join(body))
+
+
+def test_compiled_tex_uses_standalone_class(tmp_path):
+    """The wrapper template should emit `standalone` instead of article + geometry."""
+    tex_file = tmp_path / "small.tex"
+    _write_tabular(tex_file, rows=3)
+
+    TabWrap(mode=CompilerMode.CLI).compile_tex(tex_file, tmp_path, suffix="_out", keep_tex=True)
+    compiled = (tmp_path / "small_out.tex").read_text()
+
+    assert "\\documentclass[varwidth" in compiled
+    assert "{standalone}" in compiled
+    assert "\\resizebox" not in compiled
+    assert "geometry" not in compiled
+
+
+def test_tall_table_fits_single_page(tmp_path):
+    """A 30-row table used to overflow A4 onto page 2; standalone must keep it single-page."""
+    tex_file = tmp_path / "tall.tex"
+    _write_tabular(tex_file, rows=30)
+
+    result = TabWrap(mode=CompilerMode.CLI).compile_tex(tex_file, tmp_path, suffix="_out")
+    pdf_path = result.path
+
+    with fitz.open(str(pdf_path)) as doc:
+        assert len(doc) == 1, "tall table must compile to a single page under standalone"
+        page = doc[0]
+        # Page should be tightly fit, not A4 (~595x842pt). Check both dims are smaller
+        # than A4 height to confirm auto-fit, and height tracks row count (>200pt).
+        assert page.rect.width < 595
+        assert 200 < page.rect.height < 800
+
+
+def test_small_table_pdf_is_not_a4(tmp_path):
+    """Small tables should produce small PDFs — no whitespace around them."""
+    tex_file = tmp_path / "small.tex"
+    _write_tabular(tex_file, rows=2)
+
+    result = TabWrap(mode=CompilerMode.CLI).compile_tex(tex_file, tmp_path, suffix="_out")
+
+    with fitz.open(str(result.path)) as doc:
+        page = doc[0]
+        assert page.rect.width < 400, f"expected tight fit, got width={page.rect.width}"
+        assert page.rect.height < 200, f"expected tight fit, got height={page.rect.height}"
+
+
+def test_deprecated_flags_are_no_ops_and_warn(tmp_path, caplog):
+    """`landscape` and `no_rescale` should still accept input but log a deprecation warning."""
+    tex_file = tmp_path / "small.tex"
+    _write_tabular(tex_file, rows=2)
+
+    with caplog.at_level(logging.WARNING, logger="tabwrap.core"):
+        result = TabWrap(mode=CompilerMode.CLI).compile_tex(
+            tex_file,
+            tmp_path,
+            suffix="_out",
+            landscape=True,
+            no_rescale=True,
+        )
+
+    assert result.path.exists()
+    messages = " ".join(r.message for r in caplog.records)
+    assert "landscape" in messages and "no_rescale" in messages
+    assert "ignored" in messages


### PR DESCRIPTION
Closes #21.

Switches the single-table template from `article` + A4 geometry to `\documentclass[varwidth=\maxdimen,border=10pt]{standalone}`. The page auto-fits the table — fixes tall-table overflow, A4 whitespace around embedded PDFs, and ImageMagick's 1×1px crop on small tables.

`--landscape` / `--no-resize` (and their API/Python equivalents) become no-ops with a deprecation warning. Slated for removal in 2.0.

Also strips LaTeX line comments before counting `\begin`/`\end` pairs in tabular validation, so a stray `% \end{tabular}` no longer masks an unclosed environment (now needed since standalone is more lenient than the old article+resizebox setup at end-of-document).

## Test plan
- [x] Full suite passes (175 tests, +4 regression tests in `tests/test_standalone_template.py`)
- [x] Manual smoke: 30-row table compiles to a single-page PDF; small table PDF is tightly fit, not A4