### PR TITLE
Auto-inject \newcommand definitions for non-package macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Auto-inject `\newcommand` definitions for non-package macros; built-in rule for `\sym` (esttab significance stars) (#22).
+- `--preamble` flag (CLI / API / Python `compile_tex()`) for arbitrary preamble lines outside the curated rule set (#22).
+
 ### Changed
 - Single-table compiles use the `standalone` document class; pages auto-fit the table (#21).
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,11 @@ Automatically detects and includes required packages:
 - `multirow` for \\multirow
 - And many more...
 
+For commands that need a `\newcommand` rather than a package, tabwrap injects
+the definition directly. For example, `\sym{**}` from Stata's `esttab` gets a
+matching `\newcommand{\sym}` in the preamble. Use `--preamble` for arbitrary
+preamble lines outside the curated rule set.
+
 ### Flexible Output Options
 
 ```bash
@@ -161,6 +166,7 @@ Processing Options:
 Formatting Options:
   --header                 Show filename as header in output
   --packages TEXT          Comma-separated LaTeX packages (auto-detected if empty)
+  --preamble TEXT          Extra preamble lines (e.g. \newcommand) inserted verbatim after \usepackage
 
 Advanced Options:
   --keep-tex               Keep generated LaTeX files and compilation logs for debugging
@@ -184,6 +190,7 @@ tabwrap folder/ -c                    # Combined PDF with TOC
 
 # Formatting options
 tabwrap table.tex --header            # Show filename header
+tabwrap table.tex --preamble '\newcommand{\sig}[1]{\textbf{#1}}'  # Inject preamble lines (e.g. custom \newcommand)
 
 # Output control
 tabwrap table.tex -o output/          # Custom output directory

--- a/tabwrap/api.py
+++ b/tabwrap/api.py
@@ -55,6 +55,7 @@ class HealthResponse(BaseModel):
 
 class CompileOptions(BaseModel):
     packages: str = Field("", description="Comma-separated LaTeX packages")
+    preamble: str = Field("", description=r"Extra preamble lines inserted verbatim after \usepackage")
     landscape: bool = Field(False, description="[Deprecated, no-op] Output is auto-fit by the standalone document class")
     no_rescale: bool = Field(False, description="[Deprecated, no-op] Output is auto-fit by the standalone document class")
     show_filename: bool = Field(False, description="Show filename as header")
@@ -124,6 +125,7 @@ def create_app():
         request: Request,
         file: UploadFile = File(..., description="LaTeX table file (.tex)"),
         packages: str = Form("", description="Comma-separated LaTeX packages"),
+        preamble: str = Form("", description=r"Extra preamble lines inserted verbatim after \usepackage"),
         landscape: bool = Form(False, description="[Deprecated, no-op] Output is auto-fit by the standalone document class"),
         no_rescale: bool = Form(False, description="[Deprecated, no-op] Output is auto-fit by the standalone document class"),
         show_filename: bool = Form(False, description="Show filename as header"),
@@ -173,6 +175,7 @@ def create_app():
                             input_path=input_path,
                             output_dir=temp_dir,
                             packages=packages,
+                            preamble=preamble,
                             landscape=landscape,
                             no_rescale=no_rescale,
                             show_filename=show_filename,

--- a/tabwrap/cli.py
+++ b/tabwrap/cli.py
@@ -17,6 +17,11 @@ from .result import Format, resolve_formats
 @click.option("-o", "--output", type=click.Path(), default=".", help="Output directory (default: current directory)")
 @click.option("--suffix", default="_compiled", help="Output filename suffix (default: '_compiled')")
 @click.option("--packages", default="", help="Comma-separated LaTeX packages (auto-detected if empty)")
+@click.option(
+    "--preamble",
+    default="",
+    help=r"Extra preamble lines (e.g. \newcommand definitions) inserted verbatim after \usepackage lines",
+)
 @click.option("--landscape", is_flag=True, help="[Deprecated, no-op] Output is auto-fit by the standalone document class")
 @click.option("--no-resize", is_flag=True, help="[Deprecated, no-op] Output is auto-fit by the standalone document class")
 @click.option("--header", is_flag=True, help="Show filename as header in output")
@@ -42,6 +47,7 @@ def main(
     output: str,
     suffix: str,
     packages: str,
+    preamble: str,
     landscape: bool,
     no_resize: bool,
     header: bool,
@@ -95,6 +101,7 @@ def main(
                 output_dir=output,
                 suffix=suffix,
                 packages=packages,
+                preamble=preamble,
                 landscape=landscape,
                 no_rescale=no_resize,
                 show_filename=header,

--- a/tabwrap/core.py
+++ b/tabwrap/core.py
@@ -20,6 +20,7 @@ from .latex import (
     check_latex_dependencies,
     clean_filename_for_display,
     create_include_command,
+    detect_definitions,
     detect_packages,
     format_dependency_report,
     is_valid_tabular_content,
@@ -74,6 +75,7 @@ class TabWrap:
         *,
         suffix: str = "_compiled",
         packages: str = "",
+        preamble: str = "",
         # `landscape` and `no_rescale` are deprecated no-ops kept for backwards
         # compatibility with shell scripts, API form payloads, and the web UI
         # in the tabwrap-web repo. Remove in 2.0.
@@ -129,6 +131,7 @@ class TabWrap:
                 output_dir,
                 suffix=suffix,
                 packages=packages,
+                preamble=preamble,
                 landscape=landscape,
                 no_rescale=no_rescale,
                 show_filename=show_filename,
@@ -278,6 +281,14 @@ class TabWrap:
         user_packages = [f"\\usepackage{{{pkg}}}" for pkg in options.get("packages", "").split(",") if pkg]
         all_packages = "\n".join(user_packages) + "\n" + "\n".join(detected_packages)
 
+        detected_definitions = detect_definitions(content)
+        user_preamble = options.get("preamble", "") or ""
+        # User preamble runs first so a plain `\newcommand{\sym}{...}` overrides
+        # an auto-detected `\providecommand{\sym}` rule without forcing the user
+        # to remember `\renewcommand`.
+        preamble_parts = [p for p in (user_preamble, *detected_definitions) if p]
+        preamble_block = "\n".join(preamble_parts)
+
         underscore_package = ""
         if options.get("show_filename") and "_" in tex_file.name:
             underscore_package = "\\usepackage{underscore}  % Handle underscores in filenames"
@@ -288,6 +299,7 @@ class TabWrap:
 
         prepared = TexTemplates.SINGLE_TABLE.format(
             packages=all_packages,
+            preamble=preamble_block,
             underscore=underscore_package,
             header=header,
             content=content,

--- a/tabwrap/latex/__init__.py
+++ b/tabwrap/latex/__init__.py
@@ -10,7 +10,7 @@ from .error_handling import (
     format_dependency_report,
     validate_tex_content_syntax,
 )
-from .package_detection import detect_packages
+from .package_detection import detect_definitions, detect_packages
 from .templates import TexTemplates
 from .utils import clean_filename_for_display, create_include_command
 from .validation import FileValidationError, is_valid_tabular_content, validate_output_dir, validate_tex_file
@@ -20,6 +20,7 @@ __all__ = [
     "TexTemplates",
     # Utilities
     "detect_packages",
+    "detect_definitions",
     "clean_filename_for_display",
     "create_include_command",
     # Validation

--- a/tabwrap/latex/package_detection.py
+++ b/tabwrap/latex/package_detection.py
@@ -10,18 +10,33 @@ import re
 class PackageRule:
     """Represents a package detection rule."""
 
-    def __init__(self, package: str, patterns: list[str] | None = None, regex: re.Pattern | None = None):
+    def __init__(
+        self,
+        package: str | None = None,
+        patterns: list[str] | None = None,
+        regex: re.Pattern | None = None,
+        definition: str | None = None,
+    ):
         """
-        Initialize a package detection rule.
+        Initialize a detection rule.
+
+        At least one of `package` / `definition` must be set: a rule may inject a
+        `\\usepackage{...}` line, a verbatim preamble line (typically a
+        `\\newcommand`), or both.
 
         Args:
-            package: LaTeX package name (e.g., "siunitx")
-            patterns: List of literal strings to search for (e.g., ["\\num", "\\SI"])
-            regex: Compiled regex pattern for more complex detection
+            package: LaTeX package name (e.g., "siunitx").
+            patterns: List of literal strings to search for (e.g., ["\\num", "\\SI"]).
+            regex: Compiled regex pattern for more complex detection.
+            definition: Verbatim preamble line for commands that need a
+                `\\newcommand` rather than a package (e.g., esttab's `\\sym`).
         """
+        if package is None and definition is None:
+            raise ValueError("PackageRule requires at least one of `package` or `definition`")
         self.package = package
         self.patterns = patterns or []
         self.regex = regex
+        self.definition = definition
 
     def matches(self, content: str) -> bool:
         """
@@ -80,6 +95,14 @@ PACKAGE_RULES = [
     PackageRule("caption", patterns=["\\caption*", "\\captionof"]),
     # Special characters and fonts
     PackageRule("url", patterns=["\\url"]),
+    # esttab (Stata) emits \sym{**} for significance stars. Use \providecommand
+    # so we silently no-op if the user has their own \sym (e.g., from a
+    # copy-pasted preamble or via --preamble); pattern is \sym{ — the open
+    # brace — to avoid matching the kernel command \symbol.
+    PackageRule(
+        patterns=[r"\sym{"],
+        definition=r"\providecommand{\sym}[1]{\ifmmode^{#1}\else\textsuperscript{#1}\fi}",
+    ),
 ]
 
 
@@ -107,7 +130,18 @@ def detect_packages(tex_content: str) -> set[str]:
     packages = set()
 
     for rule in PACKAGE_RULES:
-        if rule.matches(tex_content):
+        if rule.package is not None and rule.matches(tex_content):
             packages.add(f"\\usepackage{{{rule.package}}}")
 
     return packages
+
+
+def detect_definitions(tex_content: str) -> list[str]:
+    """
+    Detect required preamble definitions (e.g., `\\newcommand` lines) based on content.
+
+    Mirrors :func:`detect_packages` but for rules carrying a `definition` rather
+    than (or in addition to) a package. Returns a sorted list for deterministic
+    ordering in the generated preamble.
+    """
+    return sorted({rule.definition for rule in PACKAGE_RULES if rule.definition is not None and rule.matches(tex_content)})

--- a/tabwrap/latex/templates.py
+++ b/tabwrap/latex/templates.py
@@ -13,6 +13,7 @@ class TexTemplates:
     \documentclass[varwidth=\maxdimen,border=10pt]{{standalone}}
     {underscore}
     {packages}  % Inserted packages
+    {preamble}
     \begin{{document}}
     {header}
     {content}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -170,6 +170,33 @@ def test_packages_option(client, sample_tex, tmp_path):
     assert response.headers["content-type"] == "application/pdf"
 
 
+def test_preamble_option(client, tmp_path):
+    """Test --preamble form field is accepted and the resulting PDF compiles."""
+    tex_file = tmp_path / "with_foo.tex"
+    tex_file.write_text(
+        "\n".join(
+            [
+                r"\begin{tabular}{lc}",
+                r"\toprule",
+                r"A & \foo \\",
+                r"\bottomrule",
+                r"\end{tabular}",
+                "",
+            ]
+        )
+    )
+
+    with open(tex_file, "rb") as f:
+        response = client.post(
+            "/api/compile",
+            files={"file": ("with_foo.tex", f, "text/plain")},
+            data={"preamble": r"\newcommand{\foo}{FOO}"},
+        )
+
+    assert response.status_code == 200, response.text
+    assert response.headers["content-type"] == "application/pdf"
+
+
 def test_parallel_option(client, sample_tex, tmp_path):
     """Test parallel processing option."""
     tex_file = tmp_path / "test_table.tex"

--- a/tests/test_cli_options.py
+++ b/tests/test_cli_options.py
@@ -54,6 +54,30 @@ def test_custom_packages(runner, sample_tex, tmp_path):
     assert r"\usepackage{amssymb}" in tex_content
 
 
+def test_preamble_flag_passed_through(runner, tmp_path):
+    """--preamble should inject arbitrary preamble lines verbatim."""
+    tex_file = tmp_path / "with_foo.tex"
+    tex_file.write_text(
+        "\n".join(
+            [
+                r"\begin{tabular}{lc}",
+                r"\toprule",
+                r"A & \foo \\",
+                r"\bottomrule",
+                r"\end{tabular}",
+                "",
+            ]
+        )
+    )
+    result = runner.invoke(
+        main,
+        [str(tex_file), "-o", str(tmp_path), "--preamble", r"\newcommand{\foo}{FOO}", "--keep-tex"],
+    )
+    assert result.exit_code == 0, result.output
+    compiled = (tmp_path / "with_foo_compiled.tex").read_text()
+    assert r"\newcommand{\foo}{FOO}" in compiled
+
+
 def test_no_resize_option(runner, sample_tex, tmp_path):
     """Test --no-resize option disables automatic resizing."""
     result = runner.invoke(main, [str(sample_tex), "-o", str(tmp_path), "--no-resize", "--keep-tex"])

--- a/tests/test_package_detection.py
+++ b/tests/test_package_detection.py
@@ -1,6 +1,6 @@
 """Comprehensive tests for package detection, especially edge cases."""
 
-from tabwrap.latex.package_detection import detect_packages
+from tabwrap.latex.package_detection import detect_definitions, detect_packages
 
 
 class TestSiunitxDetection:
@@ -275,3 +275,62 @@ Variable & value \\
         packages = detect_packages(content)
         # lowercase 's' shouldn't trigger siunitx
         assert r"\usepackage{siunitx}" not in packages
+
+
+class TestNewcommandDefinitions:
+    """Test rules that inject preamble definitions instead of (or alongside) packages."""
+
+    SYM_DEFINITION = r"\providecommand{\sym}[1]{\ifmmode^{#1}\else\textsuperscript{#1}\fi}"
+
+    def test_sym_emits_definition_not_package(self):
+        """`\\sym{**}` from esttab needs a preamble definition, not a \\usepackage."""
+        content = r"""
+\begin{tabular}{lc}
+\toprule
+Var & Coef \\
+\midrule
+x & 1.23\sym{**} \\
+\bottomrule
+\end{tabular}
+"""
+        assert self.SYM_DEFINITION in detect_definitions(content)
+        # No \usepackage gets emitted for \sym (no esttab package on CTAN this targets).
+        assert not any("esttab" in pkg or "sym" in pkg for pkg in detect_packages(content))
+
+    def test_no_sym_no_definition(self):
+        """Plain table without \\sym should not pull in the \\sym definition."""
+        content = r"""
+\begin{tabular}{lc}
+\toprule
+A & B \\
+\bottomrule
+\end{tabular}
+"""
+        assert detect_definitions(content) == []
+
+    def test_symbol_does_not_false_match_sym(self):
+        """The kernel command \\symbol{65} must not trigger the \\sym rule."""
+        content = r"""
+\begin{tabular}{lc}
+\toprule
+Char & Code \\
+\midrule
+A & \symbol{65} \\
+\bottomrule
+\end{tabular}
+"""
+        assert detect_definitions(content) == []
+
+    def test_package_only_rules_skip_definitions(self):
+        """Booktabs etc. carry no `definition` and must not appear in detect_definitions output."""
+        content = r"""
+\begin{tabular}{lc}
+\toprule
+A & B \\
+\midrule
+C & D \\
+\bottomrule
+\end{tabular}
+"""
+        assert r"\usepackage{booktabs}" in detect_packages(content)
+        assert detect_definitions(content) == []

--- a/tests/test_preamble_injection.py
+++ b/tests/test_preamble_injection.py
@@ -1,0 +1,126 @@
+"""Regression tests for issue #22: \\newcommand auto-injection and the --preamble escape hatch."""
+
+import pytest
+
+from tabwrap.core import CompilerMode, TabWrap
+from tabwrap.latex import check_latex_dependencies
+
+pytestmark = pytest.mark.skipif(not check_latex_dependencies()["pdflatex"], reason="pdflatex not available")
+
+
+def _write_sym_table(path) -> None:
+    body = [
+        r"\begin{tabular}{lc}",
+        r"\toprule",
+        r"Var & Coef \\",
+        r"\midrule",
+        r"x & 1.23\sym{**} \\",
+        r"y & 0.45\sym{*}  \\",
+        r"\bottomrule",
+        r"\end{tabular}",
+        "",
+    ]
+    path.write_text("\n".join(body))
+
+
+def _write_plain_table(path) -> None:
+    body = [
+        r"\begin{tabular}{lc}",
+        r"\toprule",
+        r"A & B \\",
+        r"\midrule",
+        r"C & D \\",
+        r"\bottomrule",
+        r"\end{tabular}",
+        "",
+    ]
+    path.write_text("\n".join(body))
+
+
+def test_sym_definition_auto_injected(tmp_path):
+    """`\\sym{**}` content should auto-inject the \\newcommand and compile cleanly."""
+    tex_file = tmp_path / "sym.tex"
+    _write_sym_table(tex_file)
+
+    result = TabWrap(mode=CompilerMode.CLI).compile_tex(tex_file, tmp_path, suffix="_out", keep_tex=True)
+
+    compiled = (tmp_path / "sym_out.tex").read_text()
+    assert r"\providecommand{\sym}" in compiled
+    assert result.path.exists()
+
+
+def test_user_preamble_injected_verbatim(tmp_path):
+    """The --preamble string should be inserted verbatim and usable from the body."""
+    tex_file = tmp_path / "with_foo.tex"
+    body = [
+        r"\begin{tabular}{lc}",
+        r"\toprule",
+        r"A & \foo \\",
+        r"\bottomrule",
+        r"\end{tabular}",
+        "",
+    ]
+    tex_file.write_text("\n".join(body))
+
+    result = TabWrap(mode=CompilerMode.CLI).compile_tex(
+        tex_file,
+        tmp_path,
+        suffix="_out",
+        preamble=r"\newcommand{\foo}{FOO}",
+        keep_tex=True,
+    )
+
+    compiled = (tmp_path / "with_foo_out.tex").read_text()
+    assert r"\newcommand{\foo}{FOO}" in compiled
+    assert result.path.exists()
+
+
+def test_preamble_absent_when_unused(tmp_path):
+    """A plain table with no triggering commands and no --preamble should leave the preamble area empty."""
+    tex_file = tmp_path / "plain.tex"
+    _write_plain_table(tex_file)
+
+    TabWrap(mode=CompilerMode.CLI).compile_tex(tex_file, tmp_path, suffix="_out", keep_tex=True)
+
+    compiled = (tmp_path / "plain_out.tex").read_text()
+    assert r"\newcommand" not in compiled
+    assert r"\providecommand" not in compiled
+
+
+def test_definitions_appear_after_packages(tmp_path):
+    """Definition lines must come after \\usepackage so they can rely on package-defined commands."""
+    tex_file = tmp_path / "ordered.tex"
+    _write_sym_table(tex_file)
+
+    TabWrap(mode=CompilerMode.CLI).compile_tex(tex_file, tmp_path, suffix="_out", keep_tex=True)
+
+    compiled = (tmp_path / "ordered_out.tex").read_text()
+    booktabs_idx = compiled.find(r"\usepackage{booktabs}")
+    sym_idx = compiled.find(r"\providecommand{\sym}")
+    assert booktabs_idx != -1 and sym_idx != -1
+    assert sym_idx > booktabs_idx
+
+
+def test_user_newcommand_overrides_auto_providecommand(tmp_path):
+    """User --preamble `\\newcommand{\\sym}{...}` must override the auto `\\providecommand{\\sym}`.
+
+    Auto-detected definitions use \\providecommand, and the user preamble is emitted
+    before them, so a plain \\newcommand from the user wins without needing \\renewcommand.
+    """
+    tex_file = tmp_path / "override.tex"
+    _write_sym_table(tex_file)
+
+    result = TabWrap(mode=CompilerMode.CLI).compile_tex(
+        tex_file,
+        tmp_path,
+        suffix="_out",
+        preamble=r"\newcommand{\sym}[1]{[#1]}",
+        keep_tex=True,
+    )
+
+    compiled = (tmp_path / "override_out.tex").read_text()
+    user_idx = compiled.find(r"\newcommand{\sym}[1]{[#1]}")
+    auto_idx = compiled.find(r"\providecommand{\sym}")
+    assert user_idx != -1 and auto_idx != -1
+    assert user_idx < auto_idx, "user preamble must come before auto definitions for override to work"
+    assert result.path.exists()


### PR DESCRIPTION
Closes #22.

Extends `PackageRule` so a rule can carry a verbatim preamble line (e.g. `\newcommand`) instead of (or alongside) a package, and adds a rule for esttab's `\sym{**}` significance stars. Also adds a `--preamble` CLI/API/Python flag as an escape hatch for arbitrary preamble lines outside the curated rule set.

Auto-injected `\sym` uses `\providecommand`; user `--preamble` is emitted before auto-detected definitions, so a plain `\newcommand{\sym}{...}` from the user wins without `\renewcommand`. Pattern is `\sym{` (brace-anchored) to avoid false-positives on the kernel command `\symbol`.

## Test plan
- [x] Full suite passes (186 tests, +11 covering the new detection rule, conflict-safe injection, user override, and CLI/API form-field plumbing)
- [x] Manual smoke: `\sym{**}` table compiles cleanly; `--preamble '\newcommand{\foo}{FOO}'` is inserted verbatim